### PR TITLE
fix: 잘못된 패키지명 수정

### DIFF
--- a/src/main/java/com/techcourse/aspectj/AopConfig.java
+++ b/src/main/java/com/techcourse/aspectj/AopConfig.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.EnableAspectJAutoProxy;
 
 @Configuration
 @EnableAspectJAutoProxy(proxyTargetClass = true)
-@ComponentScan(basePackages = {"camp.nextstep.aspectj", "camp.nextstep.sample"})
+@ComponentScan(basePackages = {"com.techcourse.aspectj", "com.techcourse.sample"})
 public class AopConfig {
 
     @Bean


### PR DESCRIPTION
현재, `camp.next` 와 같이 잘못된 패키지명을 가지고 있습니다.

```java
@ComponentScan(basePackages = {"camp.nextstep.aspectj", "camp.nextstep.sample"})
```

아래와 같이 수정합니다.

```java
@ComponentScan(basePackages = {"com.techcourse.aspectj", "com.techcourse.sample"})
```